### PR TITLE
fix setup_joins unpacking

### DIFF
--- a/psqlextra/query.py
+++ b/psqlextra/query.py
@@ -114,9 +114,10 @@ class PostgresQuery(sql.Query):
                         HStoreColumn(self.model._meta.db_table or self.model.name, field, hstore_key)
                     )
                     continue
-
-            _, targets, _, joins, path = self.setup_joins(parts, opts, alias, allow_many=allow_m2m)
-            targets, final_alias, joins = self.trim_joins(targets, joins, path)
+            join_info = self.setup_joins(parts, opts, alias, allow_many=allow_m2m)
+            targets, final_alias, joins = self.trim_joins(
+                join_info.targets, join_info.joins, join_info.path
+            )
 
             for target in targets:
                 cols.append(target.get_col(final_alias))


### PR DESCRIPTION
Last version of Django added a value in the returned tuple which broke the unpacking. Since Django 1.8, we can use a named tuple to avoid these breaking changes.